### PR TITLE
fix(each.py,map.py): fixed `return_exceptions` kwarg

### DIFF
--- a/paco/map.py
+++ b/paco/map.py
@@ -53,4 +53,5 @@ def map(coro, iterable, limit=0, loop=None, timeout=None,
     # Call each iterable but collecting yielded values
     return (yield from each(coro, iterable,
                             limit=limit, loop=loop,
-                            timeout=timeout, collect=True))
+                            timeout=timeout, collect=True,
+                            return_exceptions=return_exceptions))

--- a/tests/each_test.py
+++ b/tests/each_test.py
@@ -66,3 +66,16 @@ def test_each_invalid_input():
 def test_each_invalid_coro():
     with pytest.raises(TypeError):
         run_in_loop(each(None))
+
+
+def test_each_return_exceptions():
+    @asyncio.coroutine
+    def coro(num):
+        raise ValueError('foo')
+
+    task = each(coro, [1, 2, 3, 4, 5], collect=True, return_exceptions=True)
+    results = run_in_loop(task)
+    assert len(results) == 5
+
+    for err in results:
+        assert str(err) == 'foo'

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -40,3 +40,16 @@ def test_map_invalid_input():
 def test_map_invalid_coro():
     with pytest.raises(TypeError):
         run_in_loop(map(None))
+
+
+def test_map_return_exceptions():
+    @asyncio.coroutine
+    def coro(num):
+        raise ValueError('foo')
+
+    task = map(coro, [1, 2, 3, 4, 5], return_exceptions=True)
+    results = run_in_loop(task)
+    assert len(results) == 5
+
+    for err in results:
+        assert str(err) == 'foo'


### PR DESCRIPTION
Hi,

Fixed `return_exceptions` kwarg for `each` and `map` functions.
Let me know if something wrong.