### PR TITLE
Fix error importing paco in python3.7

### DIFF
--- a/paco/race.py
+++ b/paco/race.py
@@ -5,7 +5,7 @@ from .assertions import assert_iter
 try:
     from asyncio import ensure_future
 except ImportError:
-    ensure_future = asyncio.async
+    ensure_future = getattr(asyncio, 'async')
 
 
 @asyncio.coroutine


### PR DESCRIPTION
Use getattr to avoid async keyword

Fixes #41 